### PR TITLE
perf: add maps of vector index so lookups are faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs
+/x64/Debug
+/Alcatraz/x64/Debug
+/Alcatraz-gui/x64/Debug

--- a/Alcatraz-gui/Alcatraz-gui.vcxproj
+++ b/Alcatraz-gui/Alcatraz-gui.vcxproj
@@ -76,6 +76,8 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -90,6 +92,8 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -104,6 +108,8 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -120,6 +126,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Alcatraz-gui/gui/gui.cpp
+++ b/Alcatraz-gui/gui/gui.cpp
@@ -136,6 +136,7 @@ void gui::render_interface() {
 				if (ImGui::Button("Compile")) {
 					try {
 						inter::run_obfuscator(funcs_to_obfuscate, obf_entry_point);
+						MessageBoxA(0, "Compiled", "Success", 0);
 					}
 					catch (std::runtime_error e)
 					{
@@ -143,9 +144,6 @@ void gui::render_interface() {
 						path = "";
 						//std::cout << "Runtime error: " << e.what() << std::endl;
 					}
-
-					MessageBoxA(0, "Compiled", "Success", 0);
-
 				}
 			}
 			ImGui::EndChild();

--- a/Alcatraz-gui/gui/gui.cpp
+++ b/Alcatraz-gui/gui/gui.cpp
@@ -147,9 +147,9 @@ void gui::render_interface() {
 					MessageBoxA(0, "Compiled", "Success", 0);
 
 				}
-
-				ImGui::EndChild();
 			}
+			ImGui::EndChild();
+
 			
 			ImGui::SetNextWindowPos(ImVec2(400, 25));
 			ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.48f, 0.48f, 0.48f, 0.94f));

--- a/Alcatraz/Alcatraz.vcxproj
+++ b/Alcatraz/Alcatraz.vcxproj
@@ -77,6 +77,8 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -91,6 +93,8 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -105,8 +109,9 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -123,6 +128,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Alcatraz/obfuscator/misc/cfflattener.cpp
+++ b/Alcatraz/obfuscator/misc/cfflattener.cpp
@@ -147,11 +147,8 @@ bool obfuscator::flatten_control_flow(std::vector<obfuscator::function_t>::itera
 		jmp.relative.target_inst_id = current_block->block_id == 0 ? new_id : current_block->instructions.begin()->inst_id;
 		jmp.relative.target_func_id = func->func_id;
 		
-		it = func->instructions.insert(it + 1, cmp_eax);
-		it = func->instructions.insert(it + 1, jne);
-		it = func->instructions.insert(it + 1, pop_f);
-		it = func->instructions.insert(it + 1, pop_rax);
-		it = func->instructions.insert(it+1, jmp);
+		it = func->instructions.insert(it + 1, { cmp_eax , jne, pop_f, pop_rax, jmp });
+		it = it + 4;
 	}
 
 	//Fix added jz relatives
@@ -167,9 +164,8 @@ bool obfuscator::flatten_control_flow(std::vector<obfuscator::function_t>::itera
 
 	for (auto current_block = blocks.begin(); current_block != blocks.end() - 1; current_block++) {
 
-		auto last_instruction = std::find_if(func->instructions.begin(), func->instructions.end(), [&](obfuscator::instruction_t it) {
-			return it.inst_id == (current_block->instructions.end() - 1)->inst_id;
-			});
+		int instructions_index = func->inst_id_index[(current_block->instructions.end() - 1)->inst_id];
+		auto last_instruction = func->instructions.begin() + instructions_index;
 
 		auto next_block = std::find_if(blocks.begin(), blocks.end(), [&](const block_t block) {return block.block_id == current_block->next_block; });
 		if (next_block == blocks.end()) continue;
@@ -191,10 +187,8 @@ bool obfuscator::flatten_control_flow(std::vector<obfuscator::function_t>::itera
 				jmp.relative.target_func_id = func->func_id;
 				jmp.relative.target_inst_id = (func->instructions.begin() + 3)->inst_id;
 
-				last_instruction = func->instructions.insert(last_instruction + 1, push_rax);
-				last_instruction = func->instructions.insert(last_instruction + 1, push_f);
-				last_instruction = func->instructions.insert(last_instruction + 1, mov_eax);
-				last_instruction = func->instructions.insert(last_instruction + 1, jmp);
+				last_instruction = func->instructions.insert(last_instruction + 1, { push_rax , push_f, mov_eax, jmp });
+				last_instruction = last_instruction + 3;
 			}
 
 			//This happens if condition is met
@@ -211,11 +205,8 @@ bool obfuscator::flatten_control_flow(std::vector<obfuscator::function_t>::itera
 				jmp.relative.target_func_id = func->func_id;
 				jmp.relative.target_inst_id = (func->instructions.begin() + 3)->inst_id;
 
-
-				last_instruction = func->instructions.insert(last_instruction + 1, push_rax);
-				last_instruction = func->instructions.insert(last_instruction + 1, push_f);
-				last_instruction = func->instructions.insert(last_instruction + 1, mov_eax);
-				last_instruction = func->instructions.insert(last_instruction + 1, jmp);
+				last_instruction = func->instructions.insert(last_instruction + 1, { push_rax , push_f, mov_eax, jmp });
+				last_instruction = last_instruction + 3;
 			}
 
 			//Lets set the destination of our conditinal jump to our second option
@@ -236,10 +227,8 @@ bool obfuscator::flatten_control_flow(std::vector<obfuscator::function_t>::itera
 			jmp.relative.target_func_id = func->func_id;
 			jmp.relative.target_inst_id = (func->instructions.begin() + 3)->inst_id;
 
-			auto it = func->instructions.insert(last_instruction + 1, push_rax);
-			it = func->instructions.insert(it + 1, push_f);
-			it = func->instructions.insert(it + 1, mov_eax);
-			it = func->instructions.insert(it + 1, jmp);
+			auto it = func->instructions.insert(last_instruction + 1, { push_rax , push_f, mov_eax, jmp });
+			it = it + 3;
 		}
 	}
 	

--- a/Alcatraz/obfuscator/misc/cfflattener.cpp
+++ b/Alcatraz/obfuscator/misc/cfflattener.cpp
@@ -172,6 +172,7 @@ bool obfuscator::flatten_control_flow(std::vector<obfuscator::function_t>::itera
 			});
 
 		auto next_block = std::find_if(blocks.begin(), blocks.end(), [&](const block_t block) {return block.block_id == current_block->next_block; });
+		if (next_block == blocks.end()) continue;
 
 		if (is_jmp_conditional(last_instruction->zyinstr) && current_block->dst_block != -1) {
 

--- a/Alcatraz/obfuscator/obfuscator.h
+++ b/Alcatraz/obfuscator/obfuscator.h
@@ -3,6 +3,7 @@
 #include "Zydis/Zydis.h"
 #include "../pdbparser/pdbparser.h"
 
+#include <map>
 #include <string>
 #include <algorithm>
 #include <unordered_map>
@@ -14,6 +15,11 @@ private:
 	struct instruction_t;
 	struct function_t;
 	pe64* pe;
+	struct func_id_instr_id {
+		int func_id;
+		int inst_index;
+	};
+	std::map<uint64_t, func_id_instr_id> runtime_addr_track;
 
 	static int instruction_id;
 	static int function_iterator;
@@ -112,6 +118,7 @@ public:
 		int func_id;
 		std::string name;
 		std::vector<instruction_t>instructions;
+		std::map<int, uint64_t> inst_id_index;
 		uint32_t offset;
 		uint32_t size;
 
@@ -122,9 +129,8 @@ public:
 		bool mutateobf = true;
 		bool leaobf = true;
 		bool antidisassembly = true;
-
+		bool has_jumptables = false;
 	};
-
 };
 
 

--- a/Alcatraz/obfuscator/passes/mov.cpp
+++ b/Alcatraz/obfuscator/passes/mov.cpp
@@ -77,9 +77,8 @@ bool obfuscator::obfuscate_mov(std::vector<obfuscator::function_t>::iterator& fu
 			auto err = rt.add(&fn, &code);
 
 			auto jitinstructions = this->instructions_from_jit((uint8_t*)fn, code.codeSize());
-			for (auto jit : jitinstructions) {
-				instruction = function->instructions.insert(instruction + 1, jit);
-			}
+			instruction = function->instructions.insert(instruction + 1, jitinstructions.begin(), jitinstructions.end());
+			instruction = instruction + jitinstructions.size() - 1;
 
 			code.reset();
 			code.init(rt.environment());


### PR DESCRIPTION
Here is a visual studio profiler before and after this change

before
<img width="1124" alt="before" src="https://user-images.githubusercontent.com/10247765/236361577-9ebbf4ab-0d9d-4f1c-9d4c-130031eced5c.png">

after
<img width="1124" alt="after" src="https://user-images.githubusercontent.com/10247765/236361599-13e3d7d6-21ab-4f64-9abc-20a2e6f23062.png">

here is the code use in both profilers
[Alcatraz-con.zip](https://github.com/weak1337/Alcatraz/files/11402727/Alcatraz-con.zip)

The improve is about 80% less time applying all obfuscation in all functions